### PR TITLE
Enable to use the action only against the changed files in git

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ CONFLUENCE_PASSWORD: ${{ secrets.CONFLUENCE_PASSWORD }} # CONFLUENCE_PASSWORD (C
 HEADER_TEMPLATE: "---\n\n**WARNING**: This page is automatically generated from [this source code]({{source_link}})\n\n---\n" # This is a jinja template used as header, source_link is automatically resolved as github source url of the current file
 ```
 
+## Optional environment variables
+
+```yaml
+FILES: "" # space separated list of file to upload (relative to the repo root directory).
+          # if FILES is defined; DOC_DIR, DOC_DIR_PATTERN and MODIFIED_INTERVAL are ignored
+```
+
 ## Example workflow
 
 

--- a/README.md
+++ b/README.md
@@ -74,3 +74,35 @@ jobs:
 
 
 ```
+
+## Upload only changed files
+
+```yaml
+name: Docs Publish
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  pull_request:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: tj-actions/changed-files@v14.3
+      id: changed-files
+      with:
+        since_last_remote_commit: "true"
+
+    - name: Test docs generation
+      uses: draios/infra-action-mark2confluence@main
+      with:
+        action: "publish"
+        FILES: ${{ steps.changed-filed.outputs.all_changed_files }}
+        CONFLUENCE_BASE_URL: https://sysdig.atlassian.net/wiki
+        CONFLUENCE_USERNAME: ${{ secrets.CONFLUENCE_USERNAME }}
+        CONFLUENCE_PASSWORD: ${{ secrets.CONFLUENCE_PASSWORD }}
+
+```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This Action uses [mark](https://github.com/kovetskiy/mark) to accomplish this ta
 BASE_URL: https://your.confluence.url # Confluence base url of your instance
 DOC_DIR: docs # Docs directory based on the git repo root
 DOC_DIR_PATTERN: ".*" # Regexp to filter markdown files
-MODFIED_INTERVAL: "0" # Last modified files in minutes
+MODIFIED_INTERVAL: "0" # Last modified files in minutes
 CONFLUENCE_USERNAME: ${{ secrets.CONFLUENCE_USERNAME }} # CONFLUENCE_USERNAME (Confluence username) must be set in GitHub Repo secrets
 CONFLUENCE_PASSWORD: ${{ secrets.CONFLUENCE_PASSWORD }} # CONFLUENCE_PASSWORD (Confluence api key) must be set in GitHub Repo secrets
 HEADER_TEMPLATE: "---\n\n**WARNING**: This page is automatically generated from [this source code]({{source_link}})\n\n---\n" # This is a jinja template used as header, source_link is automatically resolved as github source url of the current file

--- a/README.md
+++ b/README.md
@@ -75,33 +75,28 @@ jobs:
 
 ```
 
-## Upload only changed files
+## Verify only changed files
 
 ```yaml
-name: Docs Publish
-
+name: Docs Verification
 on:
-  push:
-    branches:
-      - main
-
-jobs:
   pull_request:
+    types: [opened, edited, synchronize, reopened]
+jobs:
+  verify-markdowns:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
 
     - uses: tj-actions/changed-files@v14.3
       id: changed-files
-      with:
-        since_last_remote_commit: "true"
 
     - name: Test docs generation
       uses: draios/infra-action-mark2confluence@main
       with:
-        action: "publish"
-        FILES: ${{ steps.changed-filed.outputs.all_changed_files }}
-        CONFLUENCE_BASE_URL: https://sysdig.atlassian.net/wiki
+        action: "dry-run"
+        FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        CONFLUENCE_BASE_URL: https://your.atlassian.net/wiki
         CONFLUENCE_USERNAME: ${{ secrets.CONFLUENCE_USERNAME }}
         CONFLUENCE_PASSWORD: ${{ secrets.CONFLUENCE_PASSWORD }}
 

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: "Evaluate only files newer than (in minutes)(default: 0 means is disabled) "
     required: false
     default: "0"
+  FILES:
+    description: "Space separated list of files. When specified, the action only process the files in the list"
+    required: false
+    default: ""
   HEADER_TEMPLATE:
     description: The header to add to each markadown files, this will jinja evaluated
     required: false

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ inputs:
     required: false
     default: ""
   HEADER_TEMPLATE:
-    description: The header to add to each markadown files, this will jinja evaluated
+    description: The header to add to each markdown files, this will jinja evaluated
     required: false
     default: "---\n\n**WARNING**: This page is automatically generated from [this source code]({{source_link}})\n\n---\n"
 runs:

--- a/main.py
+++ b/main.py
@@ -134,6 +134,7 @@ def main()->int:
     topdir = os.path.join(cfg.github.WORKSPACE, cfg.inputs.DOC_DIR)
   except Exception as e:
     logger.error(f"Setup error: {e}")
+    exit(1)
 
   logger.info(f"Searching into {topdir}")
 

--- a/main.py
+++ b/main.py
@@ -132,8 +132,11 @@ def main()->int:
 
     # Search into the right directory (this runs into a docker container)
     topdir = os.path.join(cfg.github.WORKSPACE, cfg.inputs.DOC_DIR)
-  except Exception as e:
-    logger.error(f"Setup error: {e}")
+  except re.error as e:
+    logger.error(f"Setup error, DOC_DIR_PATTERN: {e}")
+    exit(1)
+  except jinja2.exceptions.TemplateError as e:
+    logger.error(f"Setup error, HEADER_TEMPLATE: {e}")
     exit(1)
 
   logger.info(f"Searching into {topdir}")


### PR DESCRIPTION
This PR adds a new feature that is mutually exclusive with the current behavior of the action: it allows the user to set the FILES environment variable with a space separated list of file paths. Those files will then, if valid mark file, be uploaded on confluence.

Setting the variable will override the previous behavior of looking into the directory and matching the file using a regex pattern.
The function is particularly useful when it's only necessary to upload the changed files in a pr/push, the README.md is updated with instructions on how to do so by using this action in combination with tj-actions/changed-files.

Proper tests are performed [here (publish)](https://github.com/gmarraff/infra-action-mark2confluence/runs/5096611938?check_suite_focus=true) and [here (dry-run)](https://github.com/gmarraff/infra-action-mark2confluence/pull/1/checks?sha=488b026fc7d4cfa672331de9d3f83c8a7b7bc0ac).