### PR TITLE
Fix get_files_by_doc_dir_pattern return condition

### DIFF
--- a/main.py
+++ b/main.py
@@ -152,7 +152,7 @@ def get_files_by_doc_dir_pattern() -> list():
       else:
         filtered_files.append(path)
 
-    return filtered_files
+  return filtered_files
 
 def main()->int:
   global cfg


### PR DESCRIPTION
The return was inside the for loop, making the function exiting
at the first iteration. This was leading to only searching in
the topdir and not properly recursing into it.