### PR TITLE
fix(mark2confluence): fix HEADER_TEMPLATE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3-slim AS builder
-ENV MARK="9.7.0"
+ENV MARK="9.9.0"
 
 ADD . /app
 WORKDIR /app

--- a/mark2confluence/main.py
+++ b/mark2confluence/main.py
@@ -28,7 +28,7 @@ DEFAULT_INPUTS = {
   "FILES": "",
   "ACTION": ACTION_DRY_RUN,
   "LOGURU_LEVEL": "INFO",
-  "HEADER_TEMPLATE": "---\n\n**WARNING**: This page is automatically generated from [this source code]({{ source_link }})\n\n---\n<!-- Include: ac:toc -->",
+  "HEADER_TEMPLATE": "---\n\n**WARNING**: This page is automatically generated from [this source code]({{ source_link }})\n\n---\n<!-- Include: ac:toc -->\n\n",
   "MODIFIED_INTERVAL": "0",
   "CONFLUENCE_PASSWORD": "",
   "CONFLUENCE_USERNAME": "",


### PR DESCRIPTION
## Changes:
* fix injected template, adding a newline after the last `toc` metadata header
```
---

**WARNING**: This page is automatically generated from [this source code](https://github.com/draios/infra-action-mark2confluence/blob/main///infra-utils-afk-workflows/docs/sudomd)

---
<!-- Include: ac:toc --># sudo
```
This was converted to a \<h1\> tag in mark `9.2.1` version, but not in `9.7.0`
* bump mark version
