### PR TITLE
fix: make verify action meaningful

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .task/*
 .venv
+venv/
 publish.sh
 main.sh
 __pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3-slim AS builder
-ENV MARK="9.9.0"
+ENV MARK="9.12.0"
 
 ADD . /app
 WORKDIR /app

--- a/mark2confluence/main.py
+++ b/mark2confluence/main.py
@@ -89,7 +89,9 @@ def publish(path: str)-> tuple:
   proc = subprocess.Popen(args, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd = os.path.dirname(path))
 
   try:
-    _, errs = proc.communicate(timeout=120)
+    out, errs = proc.communicate(timeout=120)
+    if cfg.inputs.ACTION == ACTION_VERIFY:
+      logger.info(f"Verify: mark compiled html: {out}")
   except subprocess.TimeoutExpired:
     proc.kill()
     _, errs = proc.communicate()


### PR DESCRIPTION
## Changes:
* display `mark` output when `verify` (compile-only) action is selected
* bump `mark` version (9.9.0 -> 9.12.0)