### PR TITLE
DEVOPS-13192 - Latest python version (3.12.5) does not allow quotes in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Jinja2 >= "3.0.3"
-pyaml >= "20.4.0"
-pytest >= "7.0.1"
-loguru >= "0.5.3"
-supermutes >= "0.2.5"
+Jinja2 >= 3.0.3
+pyaml >= 20.4.0
+pytest >= 7.0.1
+loguru >= 0.5.3
+supermutes >= 0.2.5


### PR DESCRIPTION
This PR fixes the requirements.txt to build with the latest Python, which for some reason introduced new constraints for requirements.txt:

Not valid in python 3.12.5:
```
$ docker run -it -v "$(pwd):$(pwd)" -w "$(pwd)" docker.io/library/python:3-slim@sha256:814d347fb3ca3efe6bc5351b47468713fc02ba9e51cb6a3fe9bb76ca600107ae bash -c "python --version; pip install -r requirements.txt --target=/test"
Python 3.12.5
ERROR: Invalid requirement: 'Jinja2 >= "3.0.3"': Expected end or semicolon (after name and no valid version specifier)
    Jinja2 >= "3.0.3"
           ^ (from line 1 of requirements.txt)
```

Valid in python 3.12.4:
```
$ docker run -it -v "$(pwd):$(pwd)" -w "$(pwd)" docker.io/library/python:3-slim@sha256:a3e58f9399353be051735f09be0316bfdeab571a5c6a24fd78b92df85bcb2d85 bash -c "python --version; pip install -r requirements.txt --target=/test"
Python 3.12.4
Collecting Jinja2>="3.0.3" (from -r requirements.txt (line 1))
  Downloading jinja2-3.1.4-py3-none-any.whl.metadata (2.6 kB)
Collecting pyaml>="20.4.0" (from -r requirements.txt (line 2))
  Downloading pyaml-24.7.0-py3-none-any.whl.metadata (11 kB)
```